### PR TITLE
fix(css): Remove underline from pagination links

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -45,12 +45,12 @@ code[class*="language-"], pre[class*="language-"] {
   color: #1EAEDB;
   background-color: #fff;
   border: 1px solid #dee2e6;
+  text-decoration: none;
 }
 
 .page-link:hover {
   z-index: 2;
   color: #0FA0CE;
-  text-decoration: none;
   background-color: #e9ecef;
   border-color: #dee2e6;
 }


### PR DESCRIPTION
Hey! Thanks for the work on this theme. I had built a script to generate package files, but a Hugo theme is much simpler.

One quick suggestion, though. Since the pagination links are already styled as buttons, they should not be underlined. If you prefer to keep the underline, feel free to close this PR!

<img width="204" alt="image" src="https://github.com/user-attachments/assets/1c6c663d-a2dc-4901-89f5-726d50d24873">
