### PR TITLE
chore(layout): Download GoDoc shield during build

### DIFF
--- a/layouts/partials/package.html
+++ b/layouts/partials/package.html
@@ -3,7 +3,9 @@
               <td><a href="https://{{ partial "repo.html" . }}">{{ partial "repo.html" . }}</a></td>
               <td>
                 <a href="https://{{ partial "doc.html" . }}">
-                  <img src="https://img.shields.io/badge/godoc-reference-blue?style=for-the-badge&color=1EAEDB" alt="GoDoc" />
+                  {{- with resources.GetRemote "https://img.shields.io/badge/godoc-reference-blue?style=for-the-badge&color=1EAEDB" }}
+                  <img src="{{ .RelPermalink }}" alt="GoDoc">
+                  {{- end }}
                 </a>
               </td>
             </tr>


### PR DESCRIPTION
As of Hugo v0.119, remote images can be downloaded during the build. This PR would make the Shields.io badge get downloaded during build, eliminating any external resources when serving the page.